### PR TITLE
解决一个内存溢出问题

### DIFF
--- a/src/CoreMiddleware.php
+++ b/src/CoreMiddleware.php
@@ -81,8 +81,6 @@ class CoreMiddleware implements CoreMiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $request = Context::set(ServerRequestInterface::class, $request);
-
         /** @var Dispatched $dispatched */
         $dispatched = $request->getAttribute(Dispatched::class);
 


### PR DESCRIPTION
Hyperf\HttpServer\Request类的getAttribute 方法会陷入死循环，导致内存溢出，程序崩溃 php_swoole_server_rshutdown,  swManager_check_exit_status: worker#0[pid=1331] abnormal exit, status=1, signal=0