### PR TITLE
当注解路由不指定path地址时默认为方法名。

### DIFF
--- a/src/Router/DispatcherFactory.php
+++ b/src/Router/DispatcherFactory.php
@@ -176,13 +176,13 @@ class DispatcherFactory
             foreach ($mappingAnnotations as $mappingAnnotation) {
                 /** @var Mapping $mapping */
                 if ($mapping = $values[$mappingAnnotation] ?? null) {
-                    if (! isset($mapping->path) || ! isset($mapping->methods) || ! isset($mapping->options)) {
+                    if (! isset($mapping->methods) || ! isset($mapping->options)) {
                         continue;
                     }
                     $methodOptions = Arr::merge($options, $mapping->options);
                     // Rewrite by annotation @Middleware for method.
                     $methodOptions['middleware'] = $options['middleware'];
-                    $path = $mapping->path;
+                    $path = isset($mapping->path) ? $mapping->path : $methodName;
 
                     if ($path === '') {
                         $path = $prefix;


### PR DESCRIPTION
更好的注解路由兼容，在使用controller路由注解时，当PostMapping、GetMapping等不指定path时默认会使用方法名。